### PR TITLE
Correct typo in mdpout.c

### DIFF
--- a/headers/asa.h
+++ b/headers/asa.h
@@ -52,6 +52,6 @@ int atom_not_in_list(s_atm *a,s_atm **atoms,int natoms);
 void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert);
 int *get_unique_atoms(s_vvertice **tvert,int nvert, int *n_ua,s_atm **p,int na);
 float *get_points_on_sphere(int nop);
-int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa);
+int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa, s_atm **ua, int n_ua);
 
 #endif

--- a/scripts/cuttree_dist.py
+++ b/scripts/cuttree_dist.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+import Pycluster
+from Pycluster import *
+from scipy.spatial import distance_matrix
+from collections import Counter
+import sys
+
+def pdb_to_data(fname):
+    data = []
+    with open(fname) as f:
+        for line in f:
+            if line.startswith("ATOM"):
+                lst = [float(s) for s in line.split()[5:8]]
+                data.append(lst)
+    return data
+
+
+def assign_id(fname, cids, fout):
+    data = pdb_to_data(fname)
+    assert(len(data) == len(cids))
+    with open(fout, "w") as f:
+        for i in range(len(data)):
+            f.write(f"ATOM  {i+1:5d}  C   PTH  {cids[i]:3d}     {data[i][0]:8.3f}{data[i][1]:8.3f}{data[i][2]:8.3f}{'0.00':>6}{'0.00':>6}\n")
+    return
+
+
+
+def assign_cluster_to_children(cid, node_id, tree, cluster_assign):
+    if node_id < 0:
+        assign_cluster_to_children(cid, tree[node_id*(-1)-1].left, tree, cluster_assign)
+        assign_cluster_to_children(cid, tree[node_id*(-1)-1].right, tree, cluster_assign)
+    else:
+        if(cluster_assign[node_id][0]!=1):
+            cluster_assign[node_id][0] = 1
+            cluster_assign[node_id][1] = cid
+    return
+
+
+def cuttree_distance(nelements, tree, distance):
+    cluster_assign = [[-1,0] for _ in range(nelements)]
+    cluster_id = 1
+    for i in range(nelements-2, -1, -1):
+        if tree[i].distance > distance:
+            if tree[i].left >= 0:
+                assign_cluster_to_children(cluster_id, tree[i].left, tree, cluster_assign)
+                cluster_id += 1
+            if tree[i].right >= 0:
+                assign_cluster_to_children(cluster_id, tree[i].right, tree, cluster_assign)
+                cluster_id += 1
+        else:
+            cluster_id += 1
+            assign_cluster_to_children(cluster_id, tree[i].left, tree, cluster_assign)
+            assign_cluster_to_children(cluster_id, tree[i].right, tree, cluster_assign)
+    return cluster_assign
+
+
+def reindex_clusters(cids):
+    reindex = {}
+    res = []
+    newid = 0
+    for cid in cids:
+        if cid in reindex:
+            res.append(reindex[cid])
+        else:
+            newid += 1
+            reindex[cid] = newid
+            res.append(newid)
+    return res
+
+
+if __name__ == "__main__":
+    data = pdb_to_data("mdpout_freq_iso_0_5.pdb")
+    print(len(data), len(data[0]))
+    dist_mtx = distance_matrix(data, data)
+    tree = treecluster( data=None, distancematrix=dist_mtx, method='s',dist='e')
+    clusters = cuttree_distance(len(data), tree, distance=2.4)
+    cids = [f[1] for f in clusters]
+    newids = reindex_clusters(cids)
+
+    size = Counter(newids)
+    print(size.most_common())
+    assign_id("mdpout_freq_iso_0_5.pdb", newids, "mdpout_freq_iso_0_5_cluster.pdb")

--- a/src/asa.c
+++ b/src/asa.c
@@ -1,4 +1,5 @@
 #include "../headers/asa.h"
+#include  <stdlib.h>
 /*
  * Copyright <2012> <Vincent Le Guilloux,Peter Schmidtke, Pierre Tuffery>
  * Copyright <2013-2018> <Peter Schmidtke, Vincent Le Guilloux>
@@ -81,31 +82,86 @@ int atom_in_list(s_atm *a, s_atm **atoms, int natoms){
         int * : atom ids of surrounding atoms
  */
 
-int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa){
+int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa, s_atm **ua, int n_ua){
     s_atm *a=NULL;
     int *sa=NULL;
     int i,z,flag=0;
     *n_sa=0;
+    s_vvertice *vcur = NULL;
+
+    float xmin = 0.0, xmax = 0.0,
+          ymin = 0.0, ymax = 0.0,
+          zmin = 0.0, zmax = 0.0,
+          xtmp = 0.0, ytmp = 0.0, ztmp = 0.0;
+          
+    for(i=0; i<nvert; i++){
+        vcur = tvert[i];
+        if(i==0){
+            xmin = vcur->x - vcur->ray - M_PADDING;
+            xmax = vcur->x + vcur->ray + M_PADDING;
+            ymin = vcur->y - vcur->ray - M_PADDING;
+            ymax = vcur->y + vcur->ray + M_PADDING;
+            zmin = vcur->z - vcur->ray - M_PADDING;
+            zmax = vcur->z + vcur->ray + M_PADDING;
+        }
+        else{
+            if (xmin > (xtmp = vcur->x - vcur->ray - M_PADDING))
+                xmin = xtmp;
+            else if (xmax < (xtmp = vcur->x + vcur->ray + M_PADDING))
+                xmax = xtmp;
+
+            if (ymin > (ytmp = vcur->y - vcur->ray - M_PADDING))
+                ymin = ytmp;
+            else if (ymax < (ytmp = vcur->y + vcur->ray + M_PADDING))
+                ymax = ytmp;
+
+            if (zmin > (ztmp = vcur->z - vcur->ray - M_PADDING))
+                zmin = ztmp;
+            else if (zmax < (ztmp = vcur->z + vcur->ray + M_PADDING))
+                zmax = ztmp;
+        }
+    }
+
     for(i=0;i<pdb->natoms;i++){
         a=pdb->latoms_p[i];
         //consider only heavy atoms for vdw incr.
-        if(strncmp(a->symbol,"H",1)){
-            flag=0;
-            for(z=0;z<nvert && !flag;z++){
-                //flag=atom_not_in_list(a,sa,*n_sa);
-                flag=in_tab(sa,*n_sa,i);
-                if(!flag && ddist(a->x,a->y,a->z,tvert[z]->x,tvert[z]->y,tvert[z]->z)<(tvert[z]->ray+M_PADDING)*(tvert[z]->ray+M_PADDING)){
-                    *n_sa=*n_sa+1;
-                    if(sa==NULL){
-                        sa=(int *)malloc(sizeof(int));
-                        sa[*n_sa-1]=i;
-                    }
-                    else {
-                        sa=(int *)realloc(sa,sizeof(int)*(*n_sa));
-                        sa[*n_sa-1]=i;
-                    }
-                }
-            }
+        xtmp = a->x;
+        ytmp = a->y;
+        ztmp = a->z;
+        if(atom_in_list(a, ua, n_ua)){
+            if(strncmp(a->symbol, "H",1)){
+              *n_sa=*n_sa+1;
+              if(sa==NULL){
+                  sa=(int *)malloc(sizeof(int));
+                  sa[*n_sa-1]=i;
+                  }
+              else {
+                  sa=(int *)realloc(sa,sizeof(int)*(*n_sa));
+                  sa[*n_sa-1]=i;
+                  }
+              continue;
+          }
+        }
+        if(xtmp>=xmin && xtmp<=xmax && ytmp>=ymin && ytmp<=ymax && ztmp>=zmin && ztmp<=zmax){
+
+          if(strncmp(a->symbol,"H",1)){
+              flag=0;
+              for(z=0;z<nvert && !flag;z++){
+                  //flag=atom_not_in_list(a,sa,*n_sa);
+                  flag=in_tab(sa,*n_sa,i);
+                  if(!flag && ddist(a->x,a->y,a->z,tvert[z]->x,tvert[z]->y,tvert[z]->z)<(tvert[z]->ray+M_PADDING)*(tvert[z]->ray+M_PADDING)){
+                      *n_sa=*n_sa+1;
+                      if(sa==NULL){
+                          sa=(int *)malloc(sizeof(int));
+                          sa[*n_sa-1]=i;
+                      }
+                      else {
+                          sa=(int *)realloc(sa,sizeof(int)*(*n_sa));
+                          sa[*n_sa-1]=i;
+                      }
+                  }
+              }
+           }
         }
     }
     return sa;
@@ -215,7 +271,43 @@ s_atm **get_unique_atoms_DEPRECATED(s_vvertice **tvert,int nvert, int *n_ua)
     return ua;
 }
 
-
+int **nei_vert_of_ua(s_vvertice **tvert, int nvert, s_atm **ua, int n_ua){
+    int **reverse_neis;
+    reverse_neis =(int **)malloc(n_ua*sizeof(int *));
+    for (int i=0; i<n_ua; i++){
+        reverse_neis[i] = (int *)malloc(nvert*sizeof(int *));
+    }
+    for(int i=0; i<n_ua; i++){
+        for(int j=0; j < nvert; j++){
+            reverse_neis[i][j] = -1;
+        }
+    }
+    //memset(reverse_neis, -1, sizeof(reverse_neis[0][0]) * n_ua * nvert);
+    s_atm **neighs = NULL ;
+    s_atm *a = NULL;
+    int i=0, z=0, j=0;
+    int n_reverse_neigh;
+    //fprintf(stdout, "%d, %d", nvert, n_ua);
+    //fprintf(stdout, "%d", reverse_neis[0][0]);
+    for(i=0; i<n_ua; i++){
+        n_reverse_neigh=0;
+        for(z=0; z<nvert; z++){
+            for(j=0; j<4; j++){
+                a = tvert[z]->neigh[j];
+                if(ua[i] == a){
+                   if(ua[i]->id != a->id) {
+                     fprintf(stdout,"WARNING asa.c: atom in the list but with different ID!") ;
+                   }
+                   //fprintf(stdout, "%d, %d", i, z);
+                   reverse_neis[i][n_reverse_neigh]=z;
+                   n_reverse_neigh += 1;
+                }
+            }
+        }
+    }
+    //fprintf(stdout, "%d", reverse_neis[0][0]);
+    return reverse_neis;
+}
 /**
    ## FUNCTION:
         set_ASA
@@ -255,10 +347,21 @@ void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
     int n_sa = 0;
     int n_ua = 0;
     int i;
-    sa=get_surrounding_atoms_idx(tvert,nvert,pdb, &n_sa);
+    //int **reverse_neis = NULL;
+    //qsort(tvert, nvert,sizeof(tvert[0]),cmp_vert);
+    //sa=get_surrounding_atoms_idx(tvert,nvert,pdb, &n_sa);
     /*ua=get_unique_atoms_DEPRECATED(tvert,nvert, &n_ua,pdb->latoms_p,pdb->natoms);*/
 
     ua=get_unique_atoms_DEPRECATED(tvert,nvert, &n_ua);
+    sa=get_surrounding_atoms_idx(tvert, nvert, pdb, &n_sa,ua,n_ua);
+    //int **reverse_neis = nei_vert_of_ua(tvert, nvert, ua, n_ua);;
+    //reverse_neis = nei_vert_of_ua(tvert, nvert, ua, n_ua);
+    //fprintf(stdout, "%d", reverse_neis[0][0]);
+    //for(int i=0; i<n_ua; i++){
+    //    for(int j=0; j<nvert; j++){
+    //        fprintf(stdout, "%d ", reverse_neis[i][j]);
+    //    }
+    //}
     float *abpatmp=NULL;
     abpatmp=(float *)my_malloc(sizeof(float)*n_ua);
 /*
@@ -303,11 +406,25 @@ void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
             ty=cura->y+curpts[3*k+1]*(cura->radius+M_PROBE_SIZE);
             tz=cura->z+curpts[3*k+2]*(cura->radius+M_PROBE_SIZE);
             vrefburried=1;
+            //for(iv=0; iv<nvert; iv++){
+            //    int vertidx = reverse_neis[i][iv];
+            //    if(vertidx == -1){
+            //        break;
+            //    }
+            //    if(ddist(tx,ty,tz,tvert[vertidx]->x,tvert[vertidx]->y,tvert[vertidx]->z)<=tvert[vertidx]->ray*tvert[vertidx]->ray){
+            //                vrefburried=0;
+            //                break;}
+            //}
             for(iv=0;iv<nvert;iv++){
                 for(vidx=0;vidx<4;vidx++){
                     if(cura==tvert[iv]->neigh[vidx]){
-                        if(ddist(tx,ty,tz,tvert[iv]->x,tvert[iv]->y,tvert[iv]->z)<=tvert[iv]->ray*tvert[iv]->ray) vrefburried=0;
+                        if(ddist(tx,ty,tz,tvert[iv]->x,tvert[iv]->y,tvert[iv]->z)<=tvert[iv]->ray*tvert[iv]->ray){
+                            vrefburried=0;
+                            break;}
                     }
+                }
+                if(!vrefburried){
+                    break;
                 }
             }
             while(!burried && j< n_sa && !vrefburried){
@@ -362,11 +479,25 @@ void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
             ty=cura->y+curpts[3*k+1]*(cura->radius+M_PROBE_SIZE2);
             tz=cura->z+curpts[3*k+2]*(cura->radius+M_PROBE_SIZE2);
             vrefburried=1;
+            //for(iv=0; iv<nvert; iv++){
+            //    int vertidx = reverse_neis[i][iv];
+            //    if(vertidx == -1){
+            //        break;
+            //    }
+            //    if(ddist(tx,ty,tz,tvert[vertidx]->x,tvert[vertidx]->y,tvert[vertidx]->z)<=tvert[vertidx]->ray*tvert[vertidx]->ray){
+            //                vrefburried=0;
+            //                break;}
+            //}
             for(iv=0;iv<nvert;iv++){
                 for(vidx=0;vidx<4;vidx++){
                     if(cura==tvert[iv]->neigh[vidx]){
-                        if(ddist(tx,ty,tz,tvert[iv]->x,tvert[iv]->y,tvert[iv]->z)<=tvert[iv]->ray*tvert[iv]->ray) vrefburried=0;
+                        if(ddist(tx,ty,tz,tvert[iv]->x,tvert[iv]->y,tvert[iv]->z)<=tvert[iv]->ray*tvert[iv]->ray) 
+                          {vrefburried=0;
+                           break;}
                     }
+                }
+                if(!vrefburried){
+                    break;
                 }
             }
             while(!burried && j< n_sa && !vrefburried){
@@ -412,6 +543,7 @@ void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
     
     free(ua);
     free(sa);
+    //free(reverse_neis);
     my_free(abpatmp);
 
     sa=NULL;
@@ -454,3 +586,6 @@ float *get_points_on_sphere(int nop) {
 }
 
 
+int cmp_vert(s_vvertice *verta, s_vvertice *vertb){
+    return ((verta->ray > vertb->ray)? -1 : 1);
+}

--- a/src/mdpocket.c
+++ b/src/mdpocket.c
@@ -426,6 +426,7 @@ void mdpocket_characterize(s_mdparams *par) {
                 fflush(stdout);
                 fprintf(fout[0], "MODEL        %d\n", i);
                 cpdb = open_pdb_file(par->fsnapshot[i],par); /*open the snapshot pdb handle*/
+                par->fpar->flag_do_asa_and_volume_calculations = 0; /*don't do ASA and volume calculations here as they are expensive and we don't need the results here*/
                 pockets = mdprocess_pdb(cpdb, par, i + 1); /*perform pocket detection on the current snapshot*/
 
                 if (i == 0)wanted_atom_ids = get_wanted_atom_ids(cpdb, wantedpocket, &nwanted_atom_ids);
@@ -450,6 +451,7 @@ void mdpocket_characterize(s_mdparams *par) {
 
                     /*get atoms contacted by the pocket*/
                     pocket_atoms = get_pocket_contacted_atms(cpocket, &natms);
+                    par->fpar->flag_do_asa_and_volume_calculations = 1; /*do ASA and volume calculations*/
                     set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, cpdb, par->fpar->flag_do_asa_and_volume_calculations);
 
                     my_free(pocket_atoms); /*free current pocket atoms*/
@@ -547,6 +549,7 @@ void mdpocket_characterize(s_mdparams *par) {
                     cur_atom->y = ts_in.coords[3 * j + 1];
                     cur_atom->z = ts_in.coords[3 * j + 2];
                 }
+                par->fpar->flag_do_asa_and_volume_calculations = 0; /*don't do ASA and volume calculations here as they are expensive and we don't need the results here*/
                 pockets = mdprocess_pdb(topology_pdb, par, k); /*perform pocket detection on the current snapshot*/
 //                fprintf(stdout, "natoms : %d\n", topology_pdb->natoms);
                 fprintf(stdout, "\r");
@@ -600,6 +603,7 @@ void mdpocket_characterize(s_mdparams *par) {
 
                     /*get atoms contacted by the pocket*/
                     pocket_atoms = get_pocket_contacted_atms(cpocket, &natms);
+                    par->fpar->flag_do_asa_and_volume_calculations = 1; /* do ASA and volume calculations. */ 
                     set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, topology_pdb, par->fpar->flag_do_asa_and_volume_calculations);
                     //if (par->fpar->flag_do_grid_calculations && k == 1) vdw_grid = init_pocket_grid(cpocket);
                     my_free(pocket_atoms); /*free current pocket atoms*/

--- a/src/mdpout.c
+++ b/src/mdpout.c
@@ -82,7 +82,7 @@ void write_md_grid(s_mdgrid *g, FILE *f, FILE *fiso,s_mdparams *par,float isoval
     fprintf(f,"# This is a standard DX file of occurences of cavities within MD trajectories.\n");
     fprintf(f,"# The file can be visualised using the freely available VMD software\n");
     fprintf(f,"# fpocket parameters used to create this dx file : \n");
-    fprintf(f,"# \t-m %2.f (min alpha sphere size) -M %.2f (max alpha sphere size)\n",par->fpar->asph_min_size, par->fpar->asph_max_size);
+    fprintf(f,"# \t-m %.2f (min alpha sphere size) -M %.2f (max alpha sphere size)\n",par->fpar->asph_min_size, par->fpar->asph_max_size);
     fprintf(f,"# \t-i %d (min number of alpha spheres per pocket)\n",par->fpar->min_pock_nb_asph);
     if(par->flag_scoring) fprintf(f,"# \t-S (Map drug score to density map!)\n");
     fprintf(f,"object 1 class gridpositions counts %d %d %d\n",g->nx,g->ny,g->nz);

--- a/src/writepocket.c
+++ b/src/writepocket.c
@@ -136,6 +136,8 @@ void write_pocket_pdb_DB(const char out[], s_pocket *pocket, s_pdb *pdb) {
     int n_sa = 0;
     int *sa = NULL; /*surrounding atoms container*/
     s_vvertice **tab_vert = NULL;
+    int n_ua = 0;
+    s_atm **ua = NULL;
 
     FILE *f = fopen(out, "w");
     if (f && pocket) {
@@ -157,7 +159,9 @@ void write_pocket_pdb_DB(const char out[], s_pocket *pocket, s_pdb *pdb) {
             nvcur = nvcur->next;
             nvert++;
         }
-        sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa);
+        ua=get_unique_atoms_DEPRECATED(tab_vert,nvert, &n_ua);
+        sa=get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa,ua,n_ua);
+        //sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa);
         for (i = 0; i < n_sa; i++) {
             //atom = pocket->sou_atoms[i] ;
             atom = pdb->latoms_p[sa[i]];


### PR DESCRIPTION
Corrected printing method for asph_min_size, otherwise asph_min_size is printed as integer in the output file, which confuses user when choosing parameters for mdpocket.