### PR TITLE
Remove memory leak

### DIFF
--- a/headers/rpdb.h
+++ b/headers/rpdb.h
@@ -139,7 +139,6 @@ s_min_max_coords *float_get_min_max_from_pdb(s_pdb *pdb);
 void init_coord_grid(s_pdb *pdb);
 void create_coord_grid(s_pdb *pdb);
 void fill_coord_grid(s_pdb *pdb);
-s_atom_ptr_list *init_atom_ptr_list(void);
 
 
 short get_mm_type_from_element(char *symbol);

--- a/src/rpdb.c
+++ b/src/rpdb.c
@@ -186,14 +186,6 @@ s_min_max_coords *float_get_min_max_from_pdb(s_pdb *pdb)
     return (NULL);
 }
 
-s_atom_ptr_list *init_atom_ptr_list()
-{
-    s_atom_ptr_list *ret = my_malloc(sizeof(s_atom_ptr_list));
-    ret->natoms = 0;
-    ret->latoms = (s_atm **)my_malloc(sizeof(s_atm *));
-    return (ret);
-}
-
 void create_coord_grid(s_pdb *pdb)
 {
     init_coord_grid(pdb);
@@ -282,7 +274,8 @@ void init_coord_grid(s_pdb *pdb)
             g->atom_ptr[cx][cy] = (s_atom_ptr_list *)my_malloc(sizeof(s_atom_ptr_list) * g->nz);
             for (cz = 0; cz < g->nz; cz++)
             {
-                g->atom_ptr[cx][cy][cz] = *init_atom_ptr_list();
+                g->atom_ptr[cx][cy][cz].natoms = 0;
+                g->atom_ptr[cx][cy][cz].latoms = (s_atm **)my_malloc(sizeof(s_atm *));
             }
         }
     }


### PR DESCRIPTION
init_atom_ptr_list() return value is dereferenced and lost forever.

Co-authored-by: EnricaColasurdo <enrica.colasurdo@gmail.com>
Co-authored-by: LucaTerruzzi <luca@terruzzi.eu>