### PR TITLE
Fix header typo for easier parsing

### DIFF
--- a/src/writepocket.c
+++ b/src/writepocket.c
@@ -607,7 +607,7 @@ void write_pocket_pdb(const char out[], s_pocket *pocket) {
         fprintf(f, "HEADER 7  - Polarity Score                    : %5d\n", pocket->pdesc->polarity_score);
         fprintf(f, "HEADER 8  - Amino Acid based volume Score     : %.4f\n", pocket->pdesc->volume_score);
         fprintf(f, "HEADER 9  - Pocket volume (Monte Carlo)       : %.4f\n", pocket->pdesc->volume);
-        fprintf(f, "HEADER 10  -Pocket volume (convex hull)       : %.4f\n", pocket->pdesc->convex_hull_volume);
+        fprintf(f, "HEADER 10 - Pocket volume (convex hull)       : %.4f\n", pocket->pdesc->convex_hull_volume);
         fprintf(f, "HEADER 11 - Charge Score                      : %5d\n", pocket->pdesc->charge_score);
         fprintf(f, "HEADER 12 - Local hydrophobic density Score   : %.4f\n", pocket->pdesc->mean_loc_hyd_dens);
         fprintf(f, "HEADER 13 - Number of apolar alpha sphere     : %5d\n", pocket->nAlphaApol);


### PR DESCRIPTION
Small syntax fix for HEADER output for pockets. Hope this helps!

Side note: The standard PDB format only allows for 1 HEADER line, which can be followed by multiple REMARK lines with additional information. Right now, the biopython PDBParser and Pymol PDB parser are unable to parse this header properly. I've written a simple python function to parse this header, (thrown together), but I think it might make sense to change the HEADER columns to REMARK, and/or release a parser for the header columns. I'm happy to make the update-

My "parser":
```python
# return a dictionary with key-value pairs of fpocket values
def extract_fpocket_pocket_info(pocket_file):
    with open(pocket_file, "r") as f:
        # headers are lines 6-20
        headers = f.readlines()[5:20]
        header_dict = dict()
        for header in headers:
            key = header[12:45].strip()
            value = header[48:].strip()
            header_dict[key] = value
        return header_dict
```