### PR TITLE
change umlauts to normal O's

### DIFF
--- a/headers/fparams.h
+++ b/headers/fparams.h
@@ -182,7 +182,7 @@ typedef struct s_fparams
 	char pdb_path[M_MAX_PDB_NAME_LEN];		/**< The pdb file */
 	char topology_path[M_MAX_PDB_NAME_LEN]; /**< a putative topology file*/
 	char custom_ligand[M_MAX_PDB_NAME_LEN]; /**container for custom pocket detection using a particular ligand*/
-	char custom_pocket_arg[M_MAX_CUSTOM_PÖCKET_LEN];
+	char custom_pocket_arg[M_MAX_CUSTOM_POCKET_LEN];
 	char **pdb_lst;
 	char xlig_chain_code[3];
 	char xlig_resname[3];

--- a/headers/utils.h
+++ b/headers/utils.h
@@ -34,7 +34,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 /* ------------------------------- PUBLIC MACROS ---------------------------- */
 
 #define M_MAX_PDB_NAME_LEN 200  /**< maximum pdb filename length*/
-#define M_MAX_CUSTOM_PÖCKET_LEN 8000 /** maximum length for a custom pocket string*/
+#define M_MAX_CUSTOM_POCKET_LEN 8000 /** maximum length for a custom pocket string*/
 #define M_SIGN 1
 #define M_NO_SIGN 0
 

--- a/src/fparams.c
+++ b/src/fparams.c
@@ -120,7 +120,7 @@ s_fparams *get_fpocket_args(int nargs, char **args)
     opterr = 0;
     char *pt;
     char *apt;
-    char *residue_string[M_MAX_CUSTOM_PÖCKET_LEN];
+    char *residue_string[M_MAX_CUSTOM_POCKET_LEN];
     short custom_ligand_i = 0;
 
     static struct option fplong_options[] = {/*long options args located in fparams.h*/


### PR DESCRIPTION
I was having the same problem as Issue #100 (Problem compiling fpocket 4.1). I found that changing the three "Ö" characters located in 'fpocket/headers/utils.h', 'fpocket/headers/fparams.h", and 'fpocket/scr/fparams.c' in the variable "M_MAX_CUSTOM_PÖCKET_LEN" with normal O's fixed the problem. 