### PR TITLE
Fix bug in ASA calculations in dpocket

### DIFF
--- a/headers/asa.h
+++ b/headers/asa.h
@@ -49,9 +49,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 int atom_not_in_list(s_atm *a,s_atm **atoms,int natoms);
-void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert);
+void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert,const char ligname[]);
 int *get_unique_atoms(s_vvertice **tvert,int nvert, int *n_ua,s_atm **p,int na);
 float *get_points_on_sphere(int nop);
-int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa);
+int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa, const char ligname[]);
 
 #endif

--- a/headers/descriptors.h
+++ b/headers/descriptors.h
@@ -90,14 +90,14 @@ typedef struct s_desc
 /* ------------------------------PROTOTYPES---------------------------------- */
 
 //explicit definition from asa.h 
-void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert);
+void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert, const char ligname[]);
 
 
 s_desc* allocate_s_desc(void) ;
 void reset_desc(s_desc *desc) ;
 
 
-void set_descriptors(s_atm **tatoms, int natoms, s_vvertice **tvert, int nvert, s_desc *desc, int niter,s_pdb *pdb,int flag_do_expensive_calculations) ;
+void set_descriptors(s_atm **tatoms, int natoms, s_vvertice **tvert, int nvert, s_desc *desc, int niter,s_pdb *pdb,int flag_do_expensive_calculations, const char ligname[]) ;
 
 int get_vert_apolar_density(s_vvertice **tvert, int nvert, s_vvertice *vert) ;
 void set_atom_based_descriptors(s_atm **atoms, int natoms, s_desc *desc,s_atm *all_atoms, int all_natoms);

--- a/headers/dpocket.h
+++ b/headers/dpocket.h
@@ -77,7 +77,7 @@ void desc_pocket(char fcomplexe[], const char ligname[], s_dparams *par,
 				 FILE *f[3]) ;
 
 s_atm** get_explicit_desc(s_pdb *pdb_cplx_l, s_lst_vvertice *verts, s_atm **lig, 
-						  int nal, s_dparams *par, int *nai, s_desc *desc) ;
+			  int nal, s_dparams *par, int *nai, s_desc *desc, const char ligname[]) ;
 
 void write_pocket_desc(const char fc[], const char l[], s_desc *d, float lv,
                        float ovlp, float dst, float c4, float c5, FILE *f) ;

--- a/src/asa.c
+++ b/src/asa.c
@@ -76,12 +76,13 @@ int atom_in_list(s_atm *a, s_atm **atoms, int natoms){
 	@ int nvert : Number of Voronoi vertices
         @ s_pdb *pdb : Structure of the protein
         @ int *n_sa : Pointer to int holding the number of surrounding atoms
+        @ const char ligname[] : Ligand residue name to exclude from protein
 
    ## RETURN:
         int * : atom ids of surrounding atoms
  */
 
-int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa){
+int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_sa, const char ligname[]){
     s_atm *a=NULL;
     int *sa=NULL;
     int i,z,flag=0;
@@ -89,7 +90,7 @@ int *get_surrounding_atoms_idx(s_vvertice **tvert,int nvert,s_pdb *pdb, int *n_s
     for(i=0;i<pdb->natoms;i++){
         a=pdb->latoms_p[i];
         //consider only heavy atoms for vdw incr.
-        if(strncmp(a->symbol,"H",1)){
+        if(strncmp(a->symbol,"H",1) && strncmp(a->res_name,ligname,3)){ 
             flag=0;
             for(z=0;z<nvert && !flag;z++){
                 //flag=atom_not_in_list(a,sa,*n_sa);
@@ -229,7 +230,7 @@ s_atm **get_unique_atoms_DEPRECATED(s_vvertice **tvert,int nvert, int *n_ua)
 	@ s_pdb *pdb : Structure containing the protein
         @ s_vvertices **tvert : List of pointers to Voronoi vertices
         @ int nvert : Number of vertices
-
+        @ const char ligname[] : Ligand residue name to exclude from protein
 
    ## RETURN:
         void
@@ -237,7 +238,7 @@ s_atm **get_unique_atoms_DEPRECATED(s_vvertice **tvert,int nvert, int *n_ua)
 
 
 
-void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
+void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert, const char ligname[])
 {
     desc->surf_pol_vdw14=0.0;
     desc->surf_apol_vdw14=0.0;
@@ -255,7 +256,7 @@ void set_ASA(s_desc *desc,s_pdb *pdb, s_vvertice **tvert,int nvert)
     int n_sa = 0;
     int n_ua = 0;
     int i;
-    sa=get_surrounding_atoms_idx(tvert,nvert,pdb, &n_sa);
+    sa=get_surrounding_atoms_idx(tvert,nvert,pdb, &n_sa, ligname);
     /*ua=get_unique_atoms_DEPRECATED(tvert,nvert, &n_ua,pdb->latoms_p,pdb->natoms);*/
 
     ua=get_unique_atoms_DEPRECATED(tvert,nvert, &n_ua);

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -150,13 +150,15 @@ void reset_desc(s_desc *desc)
 	@ s_vvertice **tvert : The list of vertices
 	@ int nvert             : The number of vertices
 	@ s_desc *desc          : OUTPUT: The descriptor structure to fill
-  
+        @ const char ligname[]  : Ligand residue name to exclude from protein (dpocket only)
+
    ## RETURN:
     void: s_desc is filled
   
 */
 void set_descriptors(s_atm **atoms, int natoms, s_vvertice **tvert, int nvert,
-					 s_desc *desc,int niter,s_pdb *pdb, int flag_do_expensive_calculations)
+		     s_desc *desc,int niter,s_pdb *pdb,
+		     int flag_do_expensive_calculations, const char ligname[])
 {
 	/* Setting atom-based descriptors */
 	set_atom_based_descriptors(atoms, natoms, desc, pdb->latoms, pdb->natoms) ;
@@ -242,11 +244,11 @@ void set_descriptors(s_atm **atoms, int natoms, s_vvertice **tvert, int nvert,
 
             if(flag_do_expensive_calculations) {
 
-            set_ASA(desc, pdb, tvert, nvert);
+            set_ASA(desc, pdb, tvert, nvert, ligname);
             desc->volume = get_verts_volume_ptr(tvert, nvert, niter,-1.6) ;
             desc->convex_hull_volume = get_convex_hull_volume(tvert,nvert);
         }
-        /*set_ASA(desc,pdb, atoms, natoms, tvert, nvert);*/
+        /*set_ASA(desc,pdb, atoms, natoms, tvert, nvert, ligname);*/
         
         
 	desc->as_max_dst = as_max_dst ;

--- a/src/dpocket.c
+++ b/src/dpocket.c
@@ -239,7 +239,7 @@ void desc_pocket(char fcomplexe[], const char ligname[], s_dparams *par,
 	verts = pockets->vertices ;
 	edesc = allocate_s_desc() ;
 	interface = get_explicit_desc(pdb_cplx_l, verts, lig, nal, par,
-								   &nai, edesc) ;
+				      &nai, edesc, ligname) ;
 
 	/* Writing output */
 	vol = get_mol_volume_ptr(lig, nal, par->fpar->nb_mcv_iter) ;
@@ -311,6 +311,7 @@ void desc_pocket(char fcomplexe[], const char ligname[], s_dparams *par,
 	@ s_dparams *par        : Parameters
 	@ int *nai              : OUTPUT Number of atom in the interface
 	@ s_desc *desc          : OUTPUT Descriptors
+	@ const char ligname[] : Ligand residue name to exclude from protein
   
    ## RETURN:
 	s_atm **: List of pointer to atoms defining the explicit pocket.
@@ -318,7 +319,8 @@ void desc_pocket(char fcomplexe[], const char ligname[], s_dparams *par,
   
 */
 s_atm** get_explicit_desc(s_pdb *pdb_cplx_l, s_lst_vvertice *verts, s_atm **lig, 
-						  int nal, s_dparams *par, int *nai, s_desc *desc)
+			  int nal, s_dparams *par, int *nai, s_desc *desc,
+			  const char ligname[])
 {
 	int nvn = 0 ;	/* Number of vertices in the interface */
 
@@ -354,7 +356,7 @@ s_atm** get_explicit_desc(s_pdb *pdb_cplx_l, s_lst_vvertice *verts, s_atm **lig,
 /*
 	fprintf(stdout, "dpocket: Calculating descriptors... ") ; fflush(stdout) ;
 */
-	set_descriptors(interface, *nai, tpverts, nvn, desc, par->fpar->nb_mcv_iter,pdb_cplx_l,par->fpar->flag_do_asa_and_volume_calculations);
+	set_descriptors(interface, *nai, tpverts, nvn, desc, par->fpar->nb_mcv_iter,pdb_cplx_l,par->fpar->flag_do_asa_and_volume_calculations,ligname);
 /*
 	fprintf(stdout, " OK\n") ;
 */

--- a/src/mdpocket.c
+++ b/src/mdpocket.c
@@ -450,7 +450,7 @@ void mdpocket_characterize(s_mdparams *par) {
 
                     /*get atoms contacted by the pocket*/
                     pocket_atoms = get_pocket_contacted_atms(cpocket, &natms);
-                    set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, cpdb, par->fpar->flag_do_asa_and_volume_calculations);
+                    set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, cpdb, par->fpar->flag_do_asa_and_volume_calculations,"");
 
                     my_free(pocket_atoms); /*free current pocket atoms*/
                     free(tab_vert); /*free tmp vertice tab*/
@@ -600,7 +600,7 @@ void mdpocket_characterize(s_mdparams *par) {
 
                     /*get atoms contacted by the pocket*/
                     pocket_atoms = get_pocket_contacted_atms(cpocket, &natms);
-                    set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, topology_pdb, par->fpar->flag_do_asa_and_volume_calculations);
+                    set_descriptors(pocket_atoms, natms, tab_vert, cpocket->v_lst->n_vertices, cpocket->pdesc, par->fpar->nb_mcv_iter, topology_pdb, par->fpar->flag_do_asa_and_volume_calculations,"");
                     //if (par->fpar->flag_do_grid_calculations && k == 1) vdw_grid = init_pocket_grid(cpocket);
                     my_free(pocket_atoms); /*free current pocket atoms*/
                     free(tab_vert); /*free tmp vertice tab*/

--- a/src/pocket.c
+++ b/src/pocket.c
@@ -614,7 +614,7 @@ void set_pockets_descriptors(c_lst_pockets *pockets,s_pdb *pdb,s_fparams *params
 
 			/* Calculate descriptors*/
 
-			set_descriptors(pocket_atoms, natms, tab_vert,pcur->v_lst->n_vertices, pcur->pdesc,niter,pdb_w_lig,params->flag_do_asa_and_volume_calculations) ;
+			set_descriptors(pocket_atoms, natms, tab_vert,pcur->v_lst->n_vertices, pcur->pdesc,niter,pdb_w_lig,params->flag_do_asa_and_volume_calculations,"") ;
                         
 			my_free(pocket_atoms) ;
 

--- a/src/writepocket.c
+++ b/src/writepocket.c
@@ -162,7 +162,7 @@ void write_pocket_pdb_DB(const char out[], s_pocket *pocket, s_pdb *pdb) {
             nvcur = nvcur->next;
             nvert++;
         }
-        sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa);
+        sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa, "");
         for (i = 0; i < n_sa; i++) {
             atom = pdb->latoms_p[sa[i]];
             write_pdb_atom_line(f, atom->type, atom->id, atom->name, atom->pdb_aloc,
@@ -210,7 +210,7 @@ void write_pocket_mmcif_DB(const char out[], s_pocket *pocket, s_pdb *pdb) {
             nvcur = nvcur->next;
             nvert++;
         }
-        sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa);
+        sa = (int *) get_surrounding_atoms_idx(tab_vert, nvert, pdb, &n_sa, "");
         for (i = 0; i < n_sa; i++) {
             atom = pdb->latoms_p[sa[i]];
             write_mmcif_atom_line(f, atom->type, atom->id, atom->name, atom->pdb_aloc,


### PR DESCRIPTION
The get_surrounding_atoms_idx() function does a full pass through the PDB and ignores hydrogen atoms but currently includes ligand atoms flagged by dpocket. This leads to differing results for all subsequent ASA descriptors (and the drug score).

The fix here just adds ligname as an argument back through the chain of calls so that residues can be skipped by name. A null string is explicitly passed for fpocket and mdpocket -- this shouldn't be a problem unless a residue has an empty name in those programs and I assume that isn't allowed.

get_surrounding_atoms_idx() is also called inside writepocket.c, which is shared by all three programs. The change here does NOT update ligname to pass through, so the results of this call are probably still different between fpocket and dpocket -- I'll regard this as aesthetic until I can find descriptor issues.